### PR TITLE
Implemented post-redirect-get mechanism for search

### DIFF
--- a/src/browser/locale/ro/LC_MESSAGES/django.po
+++ b/src/browser/locale/ro/LC_MESSAGES/django.po
@@ -7,15 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-24 09:09+0300\n"
-"PO-Revision-Date: 2025-09-24 09:15+0300\n"
+"POT-Creation-Date: 2025-09-25 20:33+0300\n"
+"PO-Revision-Date: 2025-09-25 20:34+0300\n"
 "Last-Translator: PETRU REBEJA <petru.rebeja@gmail.com>\n"
 "Language-Team: ROMANIAN\n"
 "Language: Romanian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
 
 #: src/browser/templates/base.html:10
 msgid "eDTLR browser"
@@ -29,10 +30,14 @@ msgstr "Dicționarul de Tezaur al Limbii Române"
 msgid "Search entry"
 msgstr "Căutare termen din dicționar"
 
-#: src/browser/templates/index.html:11 src/browser/templates/index.html:12
+#: src/browser/templates/index.html:12 src/browser/templates/index.html:13
 msgid "term"
 msgstr "termen"
 
-#: src/browser/templates/index.html:15
+#: src/browser/templates/index.html:16
 msgid "search"
 msgstr "caută"
+
+#: src/browser/templates/index.html:26
+msgid "No results found for"
+msgstr "Nu a fost găsit niciun rezultat pentru"

--- a/src/browser/static/browser/assets/style.css
+++ b/src/browser/static/browser/assets/style.css
@@ -38,6 +38,17 @@
     margin: 30px auto 35px;
 }
 
+.no-results{
+    margin: 1em 0 2em;
+    font-size: larger;
+    border-top: var(--bs-border-width) solid var(--bs-border-color);
+    padding: 0.5em 0;
+}
+
+.no-results p strong{
+    margin-left: 0.25em;
+}
+
 #footer{
     text-align: center;
     font-size: smaller;

--- a/src/browser/static/browser/assets/style.css
+++ b/src/browser/static/browser/assets/style.css
@@ -45,10 +45,6 @@
     padding: 0.5em 0;
 }
 
-.no-results p strong{
-    margin-left: 0.25em;
-}
-
 #footer{
     text-align: center;
     font-size: smaller;

--- a/src/browser/templates/index.html
+++ b/src/browser/templates/index.html
@@ -23,7 +23,7 @@
   {% for result in search_results %}
   {% empty %}
   <div class="no-results">
-    <p>{% translate "No results found for" %}<strong>{{search_term}}</strong>.</p>
+    <p>{% translate "No results found for" %}&nbsp;<strong>{{search_term}}</strong>.</p>
   </div>
   {% endfor %}
 </section>

--- a/src/browser/templates/index.html
+++ b/src/browser/templates/index.html
@@ -18,4 +18,14 @@
     </div>
   </form>
 </section>
+{% if search_term  %}
+<section class="search-results">
+  {% for result in search_results %}
+  {% empty %}
+  <div class="no-results">
+    <p>{% translate "No results found for" %}<strong>{{search_term}}</strong>.</p>
+  </div>
+  {% endfor %}
+</section>
+{% endif %}
 {% endblock %}

--- a/src/browser/templates/index.html
+++ b/src/browser/templates/index.html
@@ -6,11 +6,11 @@
 
 {% block content %}
 <section class="search">
-  <form action="#" method="get">
+  <form method="post" action="{% url 'browser:index'  %}">
     {% csrf_token %}
     <div class="input-group mb-3">
-      <input type="text" class="form-control" placeholder="{% translate 'term' %}"
-	     aria-label="{% translate 'term' %}" aria-describedby="btn-search">
+      <input id="term" name="term" type="text" class="form-control" placeholder="{% translate 'term' %}"
+	     aria-label="{% translate 'term' %}" aria-describedby="btn-search" value="{{search_term}}">
       <button class="btn btn-outline-secondary" type="submit" id="btn-search">
 	<i class="bi bi-search"></i>
 	{% translate 'search' %}

--- a/src/browser/views/index.py
+++ b/src/browser/views/index.py
@@ -20,10 +20,17 @@ class IndexView(View):
         request: HttpRequest, required
             The request object.
         """
-        search_term = request.GET.get('t', '')
-        return render(request,
-                      self.template_name,
-                      context={'search_term': search_term})
+        search_term = request.GET.get('t', None)
+        if search_term is None:
+            return render(request, self.template_name)
+        else:
+            search_results = []
+            return render(request,
+                          self.template_name,
+                          context={
+                              'search_term': search_term,
+                              'search_results': search_results
+                          })
 
     def post(self, request):
         """Handle the POST request.

--- a/src/browser/views/index.py
+++ b/src/browser/views/index.py
@@ -1,10 +1,16 @@
 """The index view."""
-from django.views import View
+from django.http import QueryDict
+from django.shortcuts import redirect
 from django.shortcuts import render
+from django.urls import reverse
+from django.views import View
 
 
 class IndexView(View):
     """Implements the index view."""
+
+    template_name = "index.html"
+    index_page = "browser:index"
 
     def get(self, request):
         """Handle the GET request.
@@ -14,4 +20,22 @@ class IndexView(View):
         request: HttpRequest, required
             The request object.
         """
-        return render(request, "index.html")
+        search_term = request.GET.get('t', '')
+        return render(request,
+                      self.template_name,
+                      context={'search_term': search_term})
+
+    def post(self, request):
+        """Handle the POST request.
+
+        Parameters
+        ----------
+        request: HttpRequest, required
+            The request object.
+        """
+        term = request.POST.get('term')
+        if not term:
+            return redirect(self.index_page)
+        params = QueryDict.fromkeys(['t'], value=term)
+        base_url = reverse(self.index_page)
+        return redirect(f'{base_url}?{params.urlencode()}')

--- a/src/browser/views/index.py
+++ b/src/browser/views/index.py
@@ -43,6 +43,7 @@ class IndexView(View):
         term = request.POST.get('term')
         if not term:
             return redirect(self.index_page)
-        params = QueryDict.fromkeys(['t'], value=term)
+        params = QueryDict(mutable=True)
+        params['t'] = term
         base_url = reverse(self.index_page)
         return redirect(f'{base_url}?{params.urlencode()}')


### PR DESCRIPTION
When searching for a term, the page uses a `post-redirect-get` mechanism to get the search term and load the search results. If no results are found, the home page will display a message.

This pull-request closes #5.