### PR TITLE
Implemented the search functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,5 +144,9 @@ update: schema static-files translations
 	sudo systemctl restart edtlr-browser.socket;
 	sudo systemctl restart nginx;
 
+# Import the data into the application.
+# make import IMPORT_DIR=<path> will import normally
+# make import IMPORT_DIR=<path> FORCE_IMPORT=--force will import using the --force flag
+FORCE_IMPORT ?=
 import: $(SRC_DIR)/manage.py
-	$(VENV_PYTHON) $(SRC_DIR)/manage.py importdata --input-directory $(IMPORT_DIR);
+	$(VENV_PYTHON) $(SRC_DIR)/manage.py importdata --input-directory $(IMPORT_DIR) $(FORCE_IMPORT);

--- a/README.md
+++ b/README.md
@@ -14,3 +14,37 @@ Configurearea mediului de execuție a aplicației de navigare a intrărilor din 
 3. Instalarea pachetelor necesare pentru dezvoltare.
 
 Pașii de mai sus pot fi executați rulând comanda `make dev-venv` în directorul-rădăcină al depozitului de cod, acolo unde se regăsește fișierul `Makefile`.
+
+## Importul de date
+
+Importul de date în aplicație poate fi executat în două moduri:
+- regim normal și
+- regim forțat.
+
+Fiecare dintre aceste moduri este prezentat mai jos.
+
+### Importul de date în regim normal
+
+Atunci când datele sunt importate în regim normal, aplicația iterează prin fișierele cu extensia `.xml` din directorul specificat în linia de comandă. Conținutul fiecărui fișier este citit iar valorile atributelor `md5hash` sunt comparate cu valorile respective ale intrării din baza de date, identificată după valoarea atributului `entry.id`. Dacă valorile atributelor `md5hash` sunt egale cu valorile din baza de date, aplicația trece la următorul fișier; altfel, aplicația va actualiza intrarea din baza de date cu valorile citite din fișier.
+
+Pentru a importa datele în regim normal în baza de date a aplicației, se execută (în directorul rădăcină al depozitului de cod) următoarea comandă:
+```sh
+make import IMPORT_DIR=<cale-director>
+```
+unde `<cale-director>` este calea către directorul care conține datele ce urmează să fie importate, de exemplu:
+```sh
+make import IMPORT_DIR=/tmp/edtrl-entries
+```
+
+### Importul de date în regim forțat
+
+Atunci când datele sunt importate în regim normal, aplicația iterează prin fișierele cu extensia `.xml` din directorul specificat în linia de comandă și actualizează intrările din baza de date indiferent dacă datele au fost modificate sau nu.
+
+Pentru a importa datele în regim forțat în baza de date a aplicației, se execută (în directorul rădăcină al depozitului de cod) următoarea comandă:
+```sh
+make import IMPORT_DIR=<cale-director> FORCE_IMPORT=--force
+```
+unde `<cale-director>` este calea către directorul care conține datele ce urmează să fie importate, de exemplu:
+```sh
+make import IMPORT_DIR=/tmp/edtrl-entries FORCE_IMPORT=--force
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ make import IMPORT_DIR=/tmp/edtrl-entries
 
 ### Importul de date în regim forțat
 
-Atunci când datele sunt importate în regim normal, aplicația iterează prin fișierele cu extensia `.xml` din directorul specificat în linia de comandă și actualizează intrările din baza de date indiferent dacă datele au fost modificate sau nu.
+Atunci când datele sunt importate în regim forțat, aplicația iterează prin fișierele cu extensia `.xml` din directorul specificat în linia de comandă și actualizează intrările din baza de date indiferent dacă datele au fost modificate sau nu.
 
 Pentru a importa datele în regim forțat în baza de date a aplicației, se execută (în directorul rădăcină al depozitului de cod) următoarea comandă:
 ```sh

--- a/src/browser/management/commands/importdata.py
+++ b/src/browser/management/commands/importdata.py
@@ -130,8 +130,9 @@ class EntryXmlParser:
         for elem in xml_root.iter('body'):
             md5 = elem.get('md5hash')
             paragraphs = elem.iter('paragraph')
-            html = '\n'.join([converter.convert(p.text) for p in paragraphs])
-            return (f'<article>\n{html}\n</article>', md5)
+            html = '\n'.join(
+                [f'<p>{converter.convert(p.text)}</p>' for p in paragraphs])
+            return (html, md5)
 
         return ('', '')
 

--- a/src/browser/management/commands/importdata.py
+++ b/src/browser/management/commands/importdata.py
@@ -24,14 +24,21 @@ class Command(BaseCommand):
             '--input-directory',
             help="The path of the directory containing dictionary entries.",
             required=True)
+        parser.add_argument(
+            '--force',
+            help="If specified update the entries even if MD5 sums match.",
+            required=False,
+            default=False,
+            action='store_true')
 
     def handle(self, *args, **options):
         """Import the data into the database."""
         input_dir = Path(options['input_directory'])
+        force = options['force']
 
         for entry_file in input_dir.glob("*.xml"):
             entry = self.__read_contents(entry_file)
-            if self.__update_entry(entry):
+            if self.__update_entry(entry, force):
                 style = self.style.SUCCESS
                 message = f'Entry {entry_file.stem} updated.'
             else:
@@ -41,13 +48,16 @@ class Command(BaseCommand):
 
         self.stdout.write("Finished importing data.")
 
-    def __update_entry(self, entry: Entry):
+    def __update_entry(self, entry: Entry, force: bool = False):
         """Update the specified entry if changed.
 
         Parameters
         ----------
         entry: Entry, required
             The entry to update.
+        force: bool, optional
+            If true, the entry will be updated anyway.
+            Default is 'False'.
 
         Returns
         -------
@@ -59,7 +69,7 @@ class Command(BaseCommand):
             return True
 
         db_entry = Entry.objects.get(id=entry.id)
-        if db_entry.is_equal_to(entry):
+        if db_entry.is_equal_to(entry) and not force:
             return False
 
         db_entry.copy_values_from(entry)

--- a/src/browser/static/browser/assets/style.css
+++ b/src/browser/static/browser/assets/style.css
@@ -72,6 +72,12 @@
     margin: 1em 0 1em;
 }
 
+.search-results article p
+{
+    margin: 0px;
+    line-height: 1.6;
+}
+
 #footer{
     text-align: center;
     font-size: smaller;

--- a/src/browser/static/browser/assets/style.css
+++ b/src/browser/static/browser/assets/style.css
@@ -50,11 +50,26 @@
     pointer-events: none;
 }
 
-.no-results{
+.no-results, .search-results
+{
     margin: 1em 0 2em;
-    font-size: larger;
     border-top: var(--bs-border-width) solid var(--bs-border-color);
     padding: 0.5em 0;
+}
+
+.no-results
+{
+    font-size: larger;
+}
+
+.search-results
+{
+    font-size: 1.12em;
+}
+
+.search-results article
+{
+    margin: 1em 0 1em;
 }
 
 #footer{

--- a/src/browser/templates/index.html
+++ b/src/browser/templates/index.html
@@ -21,7 +21,9 @@
 {% if search_term  %}
 <section class="search-results">
   {% for result in search_results %}
-  {{ result.text_html | safe}}
+  <article>
+    {{ result.text_html | safe}}
+  </article>
   {% empty %}
   <div class="no-results">
     <p>{% translate "No results found for" %}&nbsp;<strong>{{search_term}}</strong>.</p>

--- a/src/browser/templates/index.html
+++ b/src/browser/templates/index.html
@@ -21,6 +21,7 @@
 {% if search_term  %}
 <section class="search-results">
   {% for result in search_results %}
+  {{ result.text_html | safe}}
   {% empty %}
   <div class="no-results">
     <p>{% translate "No results found for" %}&nbsp;<strong>{{search_term}}</strong>.</p>

--- a/src/browser/views/index.py
+++ b/src/browser/views/index.py
@@ -6,6 +6,7 @@ from django.shortcuts import redirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.views import View
+import unicodedata
 
 
 class IndexView(View):
@@ -63,7 +64,24 @@ class IndexView(View):
         results: list of Entry
             The entries matching the search term.
         """
-        query = Q(title_word_normalized__icontains=term)
+        normalized_term = self.__to_normalized_form(term)
+        query = Q(title_word_normalized__icontains=normalized_term)
         query.add(Q(title_word__icontains=term), Q.OR)
         results = Entry.objects.filter(query).order_by('title_word')
         return list(results)
+
+    def __to_normalized_form(self, term: str) -> str:
+        """Convert the provided term to normalized form.
+
+        Parameters
+        ----------
+        term: str, required
+            The term to convert.
+
+        Returns
+        -------
+        normalized_term: str
+            The term in its canonical form.
+        """
+        nfkd_form = unicodedata.normalize('NFKD', term)
+        return ''.join([c for c in nfkd_form if not unicodedata.combining(c)])


### PR DESCRIPTION
- Changed the `importdata` command to force the import (as mentioned in #8), wrap each `<paragraph>` element from the input file in a `<p>` HTML tag, and not wrap the body of the entry in an `<article>` HTML tag.
- Wrap each entry in an `<article>` tag when displaying the search results.
- When searching entries, the search term is matched against the title-word of the entry, and the normalized search term is matched against the normalized title-word of each entry.

This pull-request closes #10.